### PR TITLE
Fix warnings

### DIFF
--- a/Python/rddensity/src/rddensity/rdbwdensity.py
+++ b/Python/rddensity/src/rddensity/rdbwdensity.py
@@ -70,7 +70,7 @@ def rdbwdensity(X, c=0, p=2,
     # missing values
     X = pd.DataFrame(X)
     if X.isnull().values.any():
-        warnings.warn(X.isnull().sum() + 'missing observation(s) are ignored.\n')
+        warnings.warn(f'{X.isnull().sum()} missing observation(s) are ignored.\n')
 
     X = X.dropna(axis=0)
     # sample sizes

--- a/Python/rddensity/src/rddensity/rddensity.py
+++ b/Python/rddensity/src/rddensity/rddensity.py
@@ -119,10 +119,10 @@ def rddensity(X, c=0, p=2, q=0,
     else:
         raise Exception("No more than two bandwidths are accepted.")
 
-    #missing value handling
+    # missing value handling
     X = pd.DataFrame(X)
     if X.isnull().values.any():
-        warnings.warn(X.isnull().sum() + 'missing observation(s) are ignored.\n')
+        warnings.warn(f'{X.isnull().sum()} missing observation(s) are ignored.\n')
 
     X = X.dropna(axis=0)
 

--- a/Python/rddensity/src/rddensity/rdplotdensity.py
+++ b/Python/rddensity/src/rddensity/rdplotdensity.py
@@ -90,10 +90,10 @@ def rdplotdensity(rdd, X, plotRange=None, plotN=[10], plotGrid=['es', 'qs'],
     nUniqueMin = rdd.nUniqueMin
     massPoints = rdd.massPoints
 
-    #missing value handling
+    # missing value handling
     X = pd.DataFrame(X)
     if X.isnull().values.any():
-        warnings.warn(X.isnull().sum() + 'missing observation(s) are ignored.\n')
+        warnings.warn(f'{X.isnull().sum()} missing observation(s) are ignored.\n')
 
     X = X.dropna(axis=0)
 


### PR DESCRIPTION
This is a very small fix in the Python package concerning the warnings on missing observations.

The current warning throws an error because `X.isnull().sum()` is an `int` which cannot be added to a string: `X.isnull().sum() + 'missing observation(s) are ignored.\n'`

This update uses an [f-string](https://docs.python.org/3/tutorial/inputoutput.html#tut-f-strings) to format the error message.